### PR TITLE
Updating image tag to one that exists

### DIFF
--- a/bundle/manifests/testpmd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/testpmd-operator.clusterserviceversion.yaml
@@ -130,7 +130,7 @@ spec:
                 env:
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                image: quay.io/rh-nfv-int/testpmd-operator@sha256:5bce8a08d36059d5b890f2710ecff25f16360054cf2221c84c4f6ce948b1460f
+                image: quay.io/rh-nfv-int/testpmd-operator:v0.2.4
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
The referenced SHA does not exist anymore. Switching to tag
We will figure out later regarding the use of SHA references later