### PR TITLE
Create GH action to build operator and bundle

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -3,11 +3,11 @@ name: Quay
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-?[0-9]*"
 
 env:
   REGISTRY: quay.io
+  CONNECT_REGISTRY: scan.connect.redhat.com
 
 jobs:
   build:
@@ -22,6 +22,23 @@ jobs:
 
       - name: Build and Push images
         run: |
-          org=${GITHUB_REPOSITORY%/*}
-          make all CONTAINER_CLI=docker ORG=${org}
-          make bundle-build CONTAINER_CLI=docker ORG=${org}
+          ORG=${GITHUB_REPOSITORY%/*}
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make all CONTAINER_CLI=docker ORG=${ORG} VERSION=${VERSION}
+          make bundle-build bundle-push CONTAINER_CLI=docker ORG=${ORG} VERSION=${VERSION}
+
+      - name: Login, Build and Push Operator to connect.redhat.com
+        run: |
+          echo "${{ secrets.CONNECT_TOKEN_OPERATOR }}" | docker login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make all CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_OPERATOR }} VERSION=${VERSION}
+
+      - name: Login, Build and Push Bundle to connect.redhat.com
+        run: |
+          docker logout ${CONNECT_REGISTRY}
+          echo "${{ secrets.CONNECT_TOKEN_BUNDLE }}" | docker login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make bundle-push CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_BUNDLE }} VERSION=${VERSION}

--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -3,7 +3,9 @@ name: Quay
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-?[0-9]*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+  workflow_dispatch:
 
 env:
   REGISTRY: quay.io
@@ -26,14 +28,13 @@ jobs:
           TAG=$(git tag --points-at HEAD)
           VERSION=${TAG/v/}
           make all CONTAINER_CLI=docker ORG=${ORG} VERSION=${VERSION}
-          make bundle-build bundle-push CONTAINER_CLI=docker ORG=${ORG} VERSION=${VERSION}
 
       - name: Login, Build and Push Operator to connect.redhat.com
         run: |
           echo "${{ secrets.CONNECT_TOKEN_OPERATOR }}" | docker login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
           TAG=$(git tag --points-at HEAD)
           VERSION=${TAG/v/}
-          make all CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_OPERATOR }} VERSION=${VERSION}
+          make operator-all CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_OPERATOR }} VERSION=${VERSION}
 
       - name: Login, Build and Push Bundle to connect.redhat.com
         run: |

--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -1,0 +1,27 @@
+name: Quay
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Registry login
+        run: echo "${{ secrets.QUAY_TOKEN }}" | docker login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
+
+      - name: Build and Push images
+        run: |
+          org=${GITHUB_REPOSITORY%/*}
+          make all CONTAINER_CLI=docker ORG=${org}
+          make bundle-build CONTAINER_CLI=docker ORG=${org}

--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -20,26 +20,26 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Registry login
-        run: echo "${{ secrets.QUAY_TOKEN }}" | docker login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
+        run: echo "${{ secrets.QUAY_TOKEN }}" | podman login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
 
       - name: Build and Push images
         run: |
           ORG=${GITHUB_REPOSITORY%/*}
           TAG=$(git tag --points-at HEAD)
           VERSION=${TAG/v/}
-          make all CONTAINER_CLI=docker ORG=${ORG} VERSION=${VERSION}
+          make all ORG=${ORG} VERSION=${VERSION}
 
       - name: Login, Build and Push Operator to connect.redhat.com
         run: |
-          echo "${{ secrets.CONNECT_TOKEN_OPERATOR }}" | docker login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
+          echo "${{ secrets.CONNECT_TOKEN_OPERATOR }}" | podman login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
           TAG=$(git tag --points-at HEAD)
           VERSION=${TAG/v/}
-          make operator-all CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_OPERATOR }} VERSION=${VERSION}
+          make operator-all REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_OPERATOR }} VERSION=${VERSION}
 
       - name: Login, Build and Push Bundle to connect.redhat.com
         run: |
-          docker logout ${CONNECT_REGISTRY}
-          echo "${{ secrets.CONNECT_TOKEN_BUNDLE }}" | docker login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
+          podman logout ${CONNECT_REGISTRY}
+          echo "${{ secrets.CONNECT_TOKEN_BUNDLE }}" | podman login ${CONNECT_REGISTRY} -u ${{ secrets.CONNECT_USER }} --password-stdin
           TAG=$(git tag --points-at HEAD)
           VERSION=${TAG/v/}
-          make bundle-push CONTAINER_CLI=docker REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_BUNDLE }} VERSION=${VERSION}
+          make bundle-push REGISTRY=${CONNECT_REGISTRY} ORG=${{ secrets.CONNECT_OSPID_BUNDLE }} VERSION=${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
 # Current Operator version
-TAG ?= $(shell git tag --points-at HEAD)
-REGISTRY ?= quay.io
-ORG ?= rh-nfv-int
+VERSION         := 0.2.4
+TAG             := v$(VERSION)
+REGISTRY        ?= quay.io
+ORG             ?= rh-nfv-int
 DEFAULT_CHANNEL ?= alpha
-CONTAINER_CLI ?= podman
-CLUSTER_CLI ?= oc
-OPERATOR_NAME = testpmd-operator
-VERSION := $(subst v,,$(TAG))
-
-# Fail if TAG is empty
-ifeq ($(TAG),)
-$(error TAG is emtpy)
-endif
+CONTAINER_CLI   ?= podman
+CLUSTER_CLI     ?= oc
+OPERATOR_NAME   := testpmd-operator
 
 # Default bundle image tag
 BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/$(OPERATOR_NAME)-bundle:$(TAG)
@@ -129,8 +124,16 @@ bundle: kustomize operator-sdk
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
-# Build the bundle image.
+# Build the bundle image, using local bundle image name
 .PHONY: bundle-build
 bundle-build: bundle
-	${CONTAINER_CLI} build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	${CONTAINER_CLI} build -f bundle.Dockerfile \
+		-t bundle .
+
+# Tag local bundle image with our registry BUNDLE_IMG
+bundle-tag:
+	${CONTAINER_CLI} tag bundle $(BUNDLE_IMG)
+
+# Push the BUNDLE_IMG
+bundle-push: bundle-tag
 	${CONTAINER_CLI} push $(BUNDLE_IMG)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ undeploy: kustomize
 
 # Build the operator image
 operator-build:
-	${CONTAINER_CLI} build . -t ${IMG}
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG}
 
 # Push the operator image
 operator-push:
@@ -124,17 +124,15 @@ bundle: kustomize operator-sdk
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	${CONTAINER_CLI} pull $(IMG)
-	$(eval DIGEST = $(shell ${CONTAINER_CLI} inspect $(IMG) | jq -r '.[]["Digest"]'))
-	sed -i -e 's/\(\s*image: .*\):v'$(VERSION)'/\1@'$(DIGEST)'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
-	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && sed -i -e 's/\(\s*image: .*\):v'$(VERSION)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
+	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Build the bundle image, using local bundle image name
 .PHONY: bundle-build
 bundle-build: bundle
-	${CONTAINER_CLI} build -f bundle.Dockerfile \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
 		-t bundle .
 
 # Tag local bundle image with our registry BUNDLE_IMG

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ bundle: kustomize operator-sdk
 	$(eval DIGEST = $(shell ${CONTAINER_CLI} inspect $(IMG) | jq -r '.[]["Digest"]'))
 	sed -i -e 's/\(\s*image: .*\):v'$(VERSION)'/\1@'$(DIGEST)'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Build the bundle image, using local bundle image name


### PR DESCRIPTION
- Add GH Action integration (build on tag format `vN.N.N` or `vN.N.N-N`)
  - On new tag (using a valid format) it will build and push operator and operator-bundle images
- Update Makefile to
  - Install operator-sdk if not available
  - Introduce the use of TAG
  - Sets VERSION based on TAG
  - `bundle` target now ensures operator-sdk is available
  - `bundle-build` target requires `bundle`