### PR TITLE
Using sha and bumping ansible operator version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.5.0
+FROM quay.io/operator-framework/ansible-operator:v1.7.2
 
 MAINTAINER skramaja@redhat.com
 
@@ -13,8 +13,7 @@ LABEL name="NFV Example CNF Application Opertor" \
 COPY licenses /licenses
 
 USER root
-RUN yum -y update-minimal --setopt=tsflags=nodocs \
-        --security --sec-severity=Important --sec-severity=Critical
+RUN yum -y update
 USER ansible
 
 COPY requirements.yml ${HOME}/requirements.yml

--- a/bundle/manifests/testpmd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/testpmd-operator.clusterserviceversion.yaml
@@ -193,4 +193,11 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
+  relatedImages:
+  - image: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
+    name: testpmd-app
+  - image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
+    name: testpmd-container-app-mac
+  - image: quay.io/rh-nfv-int/testpmd-operator@sha256:a725658acee30dd0d3782a2f4efee9cb949d10cf99dfd56250a8b7be34330bc7
+    name: testpmd-operator
   version: 0.2.4

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -7,6 +7,7 @@ network_defintions: ""
 network_resources: {}
 environments: {}
 image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
+mac_workaround_image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce # v0.2.0
 
 # mac workaround variables
 mac_workaround_enable: false

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-registry: quay.io
-org: rh-nfv-int
 image_pull_policy: IfNotPresent
 privileged: false
 network_defintions: ""

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -1,13 +1,12 @@
 ---
 registry: quay.io
 org: rh-nfv-int
-version: v0.2.0
 image_pull_policy: IfNotPresent
 privileged: false
 network_defintions: ""
 network_resources: {}
 environments: {}
-image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6
+image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
 
 # mac workaround variables
 mac_workaround_enable: false

--- a/roles/testpmd/tasks/main.yml
+++ b/roles/testpmd/tasks/main.yml
@@ -2,12 +2,7 @@
 - set_fact:
     network_resources: {}
     network_name_list: []
-    mac_workaround_image: "{{ registry }}/{{ org }}/testpmd-container-app-mac:{{ version }}"
-
-- name: use centos image if image_testpmd is undefined
-  set_fact:
-    image_testpmd: "{{ registry }}/{{ org }}/testpmd-container-app-testpmd:{{ version }}"
-  when: image_testpmd is undefined
+    mac_workaround_image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce # v0.2.0
 
 - name: Validate the CPUs and forwarding cores
   fail:

--- a/roles/testpmd/tasks/main.yml
+++ b/roles/testpmd/tasks/main.yml
@@ -2,7 +2,6 @@
 - set_fact:
     network_resources: {}
     network_name_list: []
-    mac_workaround_image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce # v0.2.0
 
 - name: Validate the CPUs and forwarding cores
   fail:


### PR DESCRIPTION
- In order to make the operator compatible with disconnected mode, moving to SHA references in all related images 
- Adding related images to CSV
- The ansible-operator image has a new release available, the image is based on UBI and there is no metadata available in the packages about security updates. "yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical" only works in RHEL, so it is needed to update all the packages. Certification is failing because no updates are been applied. 