### PR TITLE
Upgrade image because security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.5.0
+FROM quay.io/operator-framework/ansible-operator:v1.7.2
 
 MAINTAINER skramaja@redhat.com
 


### PR DESCRIPTION
The current image has security issues that are making the certification fail.
This change is to update to a version that does not have security patches missing.