### PR TITLE
Add relatedImages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ bundle: kustomize docker-push-with-bundle
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(eval DIGEST = $(shell skopeo inspect docker://$(IMG) | jq -r '.Digest'))
 	sed -i -e 's/\(\s*image: .*\):v'$(VERSION)'/\1@'$(DIGEST)'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	operator-sdk bundle validate ./bundle
 
 # Build the bundle image.

--- a/relatedImages.yaml
+++ b/relatedImages.yaml
@@ -3,3 +3,4 @@
       image: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1
     - name: testpmd-container-app-mac
       image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
+   

--- a/relatedImages.yaml
+++ b/relatedImages.yaml
@@ -1,7 +1,5 @@
   relatedImages:
-    - image: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
-      name: testpmd-app
-    - image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
-      name: testpmd-container-app-mac
-    - image: quay.io/rh-nfv-int/testpmd-operator@sha256:a725658acee30dd0d3782a2f4efee9cb949d10cf99dfd56250a8b7be34330bc7
-      name: testpmd-operator
+    - name: testpmd-app
+      image: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1
+    - name: testpmd-container-app-mac
+      image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce

--- a/relatedImages.yaml
+++ b/relatedImages.yaml
@@ -1,0 +1,7 @@
+  relatedImages:
+    - image: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
+      name: testpmd-app
+    - image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
+      name: testpmd-container-app-mac
+    - image: quay.io/rh-nfv-int/testpmd-operator@sha256:a725658acee30dd0d3782a2f4efee9cb949d10cf99dfd56250a8b7be34330bc7
+      name: testpmd-operator

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -7,7 +7,7 @@ privileged: false
 network_defintions: ""
 network_resources: {}
 environments: {}
-image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
+image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1
 mac_workaround_image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
 
 # mac workaround variables

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -7,7 +7,8 @@ privileged: false
 network_defintions: ""
 network_resources: {}
 environments: {}
-image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6
+image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:7a146c795271a45804209dcf3af4792498117d638c2eb4cfd69fe4cbf61d81eb
+mac_workaround_image: quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:edc9bb4724d792d415df492aea1768d4127f7fe412d99e0bee8918a8008fcbce
 
 # mac workaround variables
 mac_workaround_enable: false

--- a/roles/testpmd/tasks/main.yml
+++ b/roles/testpmd/tasks/main.yml
@@ -2,12 +2,6 @@
 - set_fact:
     network_resources: {}
     network_name_list: []
-    mac_workaround_image: "{{ registry }}/{{ org }}/testpmd-container-app-mac:{{ version }}"
-
-- name: use centos image if image_testpmd is undefined
-  set_fact:
-    image_testpmd: "{{ registry }}/{{ org }}/testpmd-container-app-testpmd:{{ version }}"
-  when: image_testpmd is undefined
 
 - name: Validate the CPUs and forwarding cores
   fail:


### PR DESCRIPTION
- Add related images template to CSV in bundle creation
- Update ansible image names to use SHA2 instead of TAGs

---

This is an initial idea on the `relatedImages` to allow the operator to work in disconnected mode.