### PR TITLE
Support vhostuser with host-device plugin

### DIFF
--- a/localtest.yaml
+++ b/localtest.yaml
@@ -13,15 +13,14 @@
       name: testpmd
     vars:
       privileged: true
-      image: jumphost.cluster5.dfwt5g.lab:5000/nfv-example-cnf/testpmd-container-app:v0.1.0
-      image_pull_policy: Always
+      image: registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6
       ethpeer_maclist:
-        - 3c:fd:fe:79:2a:a0
-        - 3c:fd:fe:79:2a:a1
+        - e4:43:4b:4a:33:82
+        - e4:43:4b:4a:33:83
       size: 1
       networks:
-        - name: vfdpdk1
-          count: 2
-      mac_workaround_enable: true
-      mac_workaround_image: "jumphost.cluster5.dfwt5g.lab:5000/nfv-example-cnf/testpmd-container-app-mac-fix:v0.1.1"
-      mac_workaround_version: "4.4"
+        - name: vhost1
+          count: 1
+        - name: vhost2
+          count: 1
+      skip_resource: true

--- a/roles/testpmd/defaults/main.yml
+++ b/roles/testpmd/defaults/main.yml
@@ -39,3 +39,4 @@ resources: []
 
 ethpeer_maclist: []
 skip_annot: false
+skip_resource: false

--- a/roles/testpmd/files/run
+++ b/roles/testpmd/files/run
@@ -5,35 +5,44 @@ set -ex
 echo "Running testpmd"
 
 RUN_APP=${run_app:=1}
+PCI_LIST=${PCI_LIST:=""}
+MODE=${MODE:-"fwd"}
 
 LOG_DIR="/var/log/testpmd"
 [ -d $LOG_DIR ] || mkdir -p $LOG_DIR
 rm -rf /var/log/testpmd/*
 
-MODE=${MODE:-"fwd"}
-
-if [ -z ${NETWORK_NAME_LIST} ]; then
-    echo "ERROR: NETWORK_NAME_LIST is required."
-    exit 1
-fi
-
 PCI=""
-IFS=',' read -r -a NETWORK_ARRAY <<< "$NETWORK_NAME_LIST"
-TESTPMD_ENV="/var/lib/testpmd/env.txt"
-echo "" > $TESTPMD_ENV
-for item in "${NETWORK_ARRAY[@]}"; do
-    IFS='/' read -r -a RES_ARRAY <<< "$item"
-    NAME="PCIDEVICE_OPENSHIFT_IO_${RES_ARRAY[1]^^}"
-    if [ -z ${!NAME} ]; then
-        echo "Could not find ${NAME} with PCI address, exiting"
+if [ ! -z ${PCI_LIST} ]; then
+    # PCI List provided as environment variable
+    IFS=',' read -r -a PCI_ARRAY <<< "${PCI_LIST}"
+    for item in "${PCI_ARRAY[@]}"; do
+        PCI=" -w ${item} "
+    done
+else
+    # Get PCI List from NETWORK_NAME_LIST environment variable
+    if [ -z ${NETWORK_NAME_LIST} ]; then
+        echo "ERROR: NETWORK_NAME_LIST is required."
         exit 1
     fi
-    echo "${NAME}=${!NAME}" >> $TESTPMD_ENV
-    IFS=',' read -r -a PCI_ARRAY <<< "${!NAME}"
-    for pci_item in "${PCI_ARRAY[@]}"; do
-        PCI+=" -w ${pci_item} "
+
+    IFS=',' read -r -a NETWORK_ARRAY <<< "$NETWORK_NAME_LIST"
+    TESTPMD_ENV="/var/lib/testpmd/env.txt"
+    echo "" > $TESTPMD_ENV
+    for item in "${NETWORK_ARRAY[@]}"; do
+        IFS='/' read -r -a RES_ARRAY <<< "$item"
+        NAME="PCIDEVICE_OPENSHIFT_IO_${RES_ARRAY[1]^^}"
+        if [ -z ${!NAME} ]; then
+            echo "Could not find ${NAME} with PCI address, exiting"
+            exit 1
+        fi
+        echo "${NAME}=${!NAME}" >> $TESTPMD_ENV
+        IFS=',' read -r -a PCI_ARRAY <<< "${!NAME}"
+        for pci_item in "${PCI_ARRAY[@]}"; do
+            PCI+=" -w ${pci_item} "
+        done
     done
-done
+fi
 
 LCORES=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
 if [ -z $LCORES ]; then

--- a/roles/testpmd/files/run
+++ b/roles/testpmd/files/run
@@ -17,7 +17,7 @@ if [ ! -z ${PCI_LIST} ]; then
     # PCI List provided as environment variable
     IFS=',' read -r -a PCI_ARRAY <<< "${PCI_LIST}"
     for item in "${PCI_ARRAY[@]}"; do
-        PCI=" -w ${item} "
+        PCI+=" -w ${item} "
     done
 else
     # Get PCI List from NETWORK_NAME_LIST environment variable

--- a/roles/testpmd/tasks/host-device.yaml
+++ b/roles/testpmd/tasks/host-device.yaml
@@ -1,0 +1,17 @@
+---
+- name: "Create network name list (resource list)"
+  set_fact:
+    network_name_list: "{{ network_name_list + [ network_item.name ] }}"
+
+- name: "Get NetworkAttachmentDefinition for network {{ network_item.name }}"
+  set_fact:
+    net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=network_item.name) }}"
+  failed_when: net_def|length == 0
+
+- name: "Get CNI spec data from NetworkAttachmentDefinition"
+  set_fact:
+    cni_config: "{{ net_def['spec']['config'] }}"
+
+- name: "Get PCI id from cni config"
+  set_fact:
+    pci_list: "{{ pci_list + [ cni_config.pciBusId ] }}"

--- a/roles/testpmd/tasks/main.yml
+++ b/roles/testpmd/tasks/main.yml
@@ -2,10 +2,11 @@
 - set_fact:
     network_resources: {}
     network_name_list: []
+    pci_list: []
 
 - name: Validate the CPUs and forwarding cores
   fail:
-    msg: "{{ forwarding_cores }} should be lesser than {{ cpu }}"
+    msg: "forwarding cores ({{ forwarding_cores }}) should be lesser than requested cpu({{ cpu }})"
   when: forwarding_cores|int >= cpu|int
 
 - name: print network list
@@ -42,9 +43,18 @@
         run: |
           {{ lookup('file', 'run') }}
 
-- name: "Parse network"
+- name: "Parse network for sriov cni"
   include_tasks: network-parse.yaml
-  when: networks|default([])|length > 0
+  when:
+  - networks|default([])|length > 0
+  - not skip_resource|bool
+  loop: "{{ networks }}"
+  loop_control:
+    loop_var: network_item
+
+- name: "Parse network for host-device plugin"
+  include_tasks: host-device.yaml
+  when: networks|length > 0 and skip_resource|bool
   loop: "{{ networks }}"
   loop_control:
     loop_var: network_item

--- a/roles/testpmd/tasks/network-parse.yaml
+++ b/roles/testpmd/tasks/network-parse.yaml
@@ -17,7 +17,8 @@
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"
 
-- set_fact:
+- name: "set resource name from the networkattachmentdefinition's annotations"
+  set_fact:
     network_resource_name: "{{ net_def['metadata']['annotations']['k8s.v1.cni.cncf.io/resourceName'] }}"
 
 - set_fact:

--- a/roles/testpmd/templates/deployment.yml
+++ b/roles/testpmd/templates/deployment.yml
@@ -95,6 +95,8 @@ spec:
           value: "{{ eth_peer }}"
         - name: socket_mem
           value: "{{ socket_memory }}"
+        - name: forwarding_cores
+          value: "{{ forwarding_cores }}"
         - name: memory_channels
           value: "{{ memory_channels }}"
         - name: rx_queues
@@ -105,6 +107,10 @@ spec:
           value: "{{ rx_descriptors }}"
         - name: tx_descriptors
           value: "{{ tx_descriptors }}"
+{% if pci_list|length > 0 %}
+        - name: PCI_LIST
+          value: "{{ pci_list|join(',') }}"
+{% endif %}
 {% for key, value in environments.items() %}
         - name: {{ key }}
           value: "{{ value }}"


### PR DESCRIPTION
When using host-device plugin, the net-attach-def
resources are created via additionalNetworks of
cluster network definition. It does not use the
node resource mapping but only the networks. Allow
vhostuser deployment to skip resources and fetch
PCI address from net-attach-def and provide to
the application.